### PR TITLE
GHA: Use cache of actions/setup-java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,7 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
-      - name: Cache the Maven local repository
-        uses: actions/cache@v3.0.7
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-${{ matrix.java }}-
+          cache: maven
       - name: Build the project
         run: mvn -B clean install
       - name: Get the project version


### PR DESCRIPTION
## Describe the changes

In the GitHub Actions build workflow, use the actions/setup-java cache feature instead of actions/cache.
